### PR TITLE
Pythonicizing the python script.

### DIFF
--- a/scripts/average.py
+++ b/scripts/average.py
@@ -1,8 +1,14 @@
 #!/usr/bin/env python
 
-import os, sys
+from __future__ import print_function
+
+import os
+import sys
 import argparse
 
+import numpy as np
+
+# Parse arguments.
 parser = argparse.ArgumentParser()
 parser.add_argument('-m', '--model', nargs='+', required=True,
                     help="Models to average")
@@ -10,24 +16,30 @@ parser.add_argument('-o', '--output', required=True,
                     help="Output path")
 args = parser.parse_args()
 
-import numpy as np;
-
+# *average* holds the model matrix.
 average = dict()
+# No. of models.
 n = len(args.model)
+
 for filename in args.model:
-  print "Loading", filename 
-  with open(filename, "rb") as mfile:
-    m = np.load(mfile)
-    for k in m:
-      if k != "history_errs":
-        if k not in average:
-          average[k] = m[k]
-        elif average[k].shape == m[k].shape and "special" not in k:
-          average[k] += m[k]
+    print("Loading {}".format(filename))
+    with open(filename, "rb") as mfile:
+        # Loads matrix from model file.
+        m = np.load(mfile)
+        for k in m:
+            if k != "history_errs":
+                # Initialize the key.
+                if k not in average:
+                    average[k] = m[k]
+                # Add to the appropriate value.
+                elif average[k].shape == m[k].shape and "special" not in k:
+                    average[k] += m[k]
 
+# Actual averaging.
 for k in average:
-  if "special" not in k:
-    average[k] /= n
+    if "special" not in k:
+        average[k] /= n
 
-print "Saving to", args.output
+# Save averaged model to file.
+print("Saving to {}".format(args.output))
 np.savez(args.output, **average)

--- a/scripts/dropout.py
+++ b/scripts/dropout.py
@@ -1,9 +1,14 @@
 #!/usr/bin/env python
 
-import os, sys
-import argparse
-import numpy as np;
+from __future__ import print_function
 
+import os
+import sys
+import argparse
+
+import numpy as np
+
+# Parse arguments.
 parser = argparse.ArgumentParser()
 parser.add_argument('-d', '--dropout', type=float, required=True,
                     help="dropout rate")
@@ -13,18 +18,25 @@ parser.add_argument('-o', '--output', required=True,
                     help="Output model")
 args = parser.parse_args()
 
-
+# Set dropout multiplier.
 multiplier = 1.0 - args.dropout
-
+# *output* holds the output matrix that has been "dropped out".
 output = dict()
-print "Loading", args.input, "to multiple with", multiplier
-with open(args.input, "rb") as mfile:
-  m = np.load(mfile)
-  for k in m:
-    if "history_errs" in k or "_b" in k or "c_tt" in k:
-      output[k] = m[k]
-    else:
-      output[k] = multiplier * m[k]
 
-print "Saving to", args.output
+
+print("Loading {} to multiply with {}".format(args.input, multiplier)
+
+with open(args.input, "rb") as mfile:
+    # Loads the matrix from model file.
+    m = np.load(mfile)
+    for k in m:
+        # Initialize the key.
+        if "history_errs" in k or "_b" in k or "c_tt" in k:
+            output[k] = m[k]
+        # Multiply the dropout multipier.
+        else:
+            output[k] = multiplier * m[k]
+
+# Save the "dropped out" model.
+print("Saving to {}".format(args.output))
 np.savez(args.output, **output)

--- a/scripts/pkl2json.py
+++ b/scripts/pkl2json.py
@@ -1,8 +1,13 @@
 #!/usr/bin/env python
-import sys
-import cPickle
-import json
-import operator
 
-d = cPickle.load(open(sys.argv[1], 'r'))
-json.dump(d, sys.stdout)
+import sys
+import json
+
+try:
+    import cPickle as pickle
+except ImportError:
+    import pickle
+
+with open(sys.argv[1], 'r') as fin:
+    d = pickle.load(fin)
+    json.dump(d, sys.stdout)

--- a/scripts/pkl2yaml.py
+++ b/scripts/pkl2yaml.py
@@ -1,9 +1,15 @@
 #!/usr/bin/env python
-import sys
-import cPickle
-import yaml
-import operator
 
-d = cPickle.load(open(sys.argv[1], 'r'))
-yaml.safe_dump(d, sys.stdout,
-               default_flow_style=False, allow_unicode=True)
+import sys
+import yaml
+
+try:
+    import cPickle as pickle
+except ImportError:
+    import pickle
+
+with open(sys.argv[1], 'r') as fin:
+    d = pickle.load(fin)
+    yaml.safe_dump(d, sys.stdout,
+                   default_flow_style=False,
+                   allow_unicode=True)

--- a/scripts/s2s2amun.py
+++ b/scripts/s2s2amun.py
@@ -1,8 +1,12 @@
 #!/usr/bin/python
 
-import argparse
-import numpy
+from __future__ import print_function
 
+import argparse
+
+import numpy as np
+
+# Parse arguments.
 parser = argparse.ArgumentParser()
 parser.add_argument('-i', '--s2s', required=True,
                     help="S2S Model")
@@ -10,7 +14,8 @@ parser.add_argument('-o', '--amun', required=True,
                     help="Amun Model")
 args = parser.parse_args()
 
-mapping = { "decoder_cell1_U":  "decoder_U", 
+# Mappings from Seq2Seq to Amun.
+mapping = { "decoder_cell1_U":  "decoder_U",
             "decoder_cell1_Ux": "decoder_Ux",
             "decoder_cell1_W":  "decoder_W",
             "decoder_cell1_Wx": "decoder_Wx",
@@ -71,18 +76,23 @@ mapping = { "decoder_cell1_U":  "decoder_U",
             "encoder_bi_r_gamma2": "encoder_r_gamma2" }
 
 
-print "[s2s2amun] Loading s2s model", args.s2s
-s2s_model = numpy.load(args.s2s)
+# Loads the Seq2Seq model.
+print("[s2s2amun] Loading s2s model {}".format(args.s2s))
+s2s_model = np.load(args.s2s)
+# *amun_model* holds the output model.
 amun_model = dict()
-for tensor_name in s2s_model:
-  if tensor_name in mapping:
-    amun_model[ mapping[ tensor_name ]] = s2s_model[ tensor_name ]
-  else:
-    print "[s2s2amun] unknown", tensor_name
 
-decoder_c_tt = numpy.array([0])
+for tensor_name in s2s_model:
+    # Substitute the mapping.
+    if tensor_name in mapping:
+        amun_model[ mapping[ tensor_name ]] = s2s_model[ tensor_name ]
+    # Otherwise, notify user of unknown tensor.
+    else:
+        print("[s2s2amun] unknown: {}".format(tensor_name))
+
+decoder_c_tt = np.array([0])
 amun_model[ "decoder_c_tt" ] = decoder_c_tt
 
-print "[s2s2amun] Saving amun model", args.amun
-numpy.savez(args.amun, **amun_model)
-
+# Saves the Amun model.
+print("[s2s2amun] Saving amun model: {}".format(args.amun))
+np.savez(args.amun, **amun_model)


### PR DESCRIPTION
Making the `average.py`, `dropout.py` and `s2s2amun.py` more pythonic

 - moves `import`s to the top
 - use modern (`__future__`) print function
 - use modern string formatting
 - added some comments to the scripts. 
 - proper indentation

----

Making `pk2json.py` and `pkl2yaml.py` more pythonic

 - support py2 and py3 pickling
 - removed unused import 


I hope this helps. 

Is there a unittest module that we can run to test the new scripts?