### PR TITLE
Use devel for NVCC support

### DIFF
--- a/scripts/docker/Dockerfile.gpu
+++ b/scripts/docker/Dockerfile.gpu
@@ -1,4 +1,4 @@
-FROM nvidia/cuda:8.0-cudnn6-runtime-ubuntu16.04
+FROM nvidia/cuda:8.0-devel-ubuntu16.04
 
 MAINTAINER Mama <ma@ma.com>
 LABEL description="Basic Marian nvidia-docker container for Ubuntu"


### PR DESCRIPTION
Cuda images with `runtime` doesn't have the compilers available and only Amun got installed.

Using `8.0-devel-ubuntu16.04` instead of `8.0-runtime-ubuntu16.04` will include the compiler.