### PR TITLE
Return results of python api as list

### DIFF
--- a/src/amun/python/amunmt.cpp
+++ b/src/amun/python/amunmt.cpp
@@ -79,11 +79,15 @@ boost::python::list translate(boost::python::list& in)
   allHistories.SortByLineNum();
 
   // output
-  std::stringstream ss;
-  Printer(god_, allHistories, ss);
-  string str = ss.str();
   boost::python::list output;
-  output.append(str);
+  for (size_t i = 0; i < allHistories.size(); ++i) {
+    const History& history = *allHistories.at(i).get();
+    std::stringstream ss;
+    Printer(god_, history, ss);
+    string str = ss.str();
+
+    output.append(str);
+  }
 
   return output;
 }


### PR DESCRIPTION
The current python API accepts a list of strings to be translated as input and returns a list consisting of a single string which contains the translation.
This PR changes the returned value to be a list whereas each entry corresponds to a translation of the input list