### PR TITLE
[Do NOT merge] Add Nematus-style factor support

### DIFF
--- a/src/amun/CMakeLists.txt
+++ b/src/amun/CMakeLists.txt
@@ -61,6 +61,7 @@ add_library(libcommon OBJECT
   common/types.cpp
   common/utils.cpp
   common/vocab.cpp
+  common/factor_vocab.cpp
   common/translation_task.cpp
 )
 

--- a/src/amun/common/config.cpp
+++ b/src/amun/common/config.cpp
@@ -43,7 +43,6 @@ void ProcessPaths(YAML::Node& node, const boost::filesystem::path& configPath, b
     if(node.Type() == YAML::NodeType::Sequence) {
       for(auto&& sub : node) {
         ProcessPaths(sub, configPath, true);
-        break;
       }
     }
   }

--- a/src/amun/common/factor_vocab.cpp
+++ b/src/amun/common/factor_vocab.cpp
@@ -1,0 +1,36 @@
+#include "common/factor_vocab.h"
+
+namespace amunmt {
+
+  FactorVocab::FactorVocab(const std::string& path) {
+    vocabs_.emplace_back(new Vocab(path));
+  }
+
+  FactorVocab::FactorVocab(const std::vector<std::string>& paths) {
+    for (auto path : paths) {
+      vocabs_.emplace_back(new Vocab(path));
+    }
+  }
+
+  FactWord FactorVocab::operator[](const std::vector<std::string>& factors) const {
+    FactWord factorIds(factors.size());
+    for (size_t i = 0; i < factors.size(); ++i) {
+      const std::string& factor = factors[i];
+      factorIds[i] = (*vocabs_[i])[factor];
+    }
+    return factorIds;
+  }
+
+  FactWords FactorVocab::operator()(const std::vector<std::vector<std::string>>& lineFactors, bool addEOS) const {
+    FactWords words(lineFactors.size());
+    std::transform(lineFactors.begin(), lineFactors.end(), words.begin(),
+                   [&](const std::vector<std::string>& factors) {return (*this)[factors];});
+    if(addEOS)
+      words.push_back(FactWord(words.back().size(), EOS_ID));
+    return words;
+  }
+
+  Vocab& FactorVocab::GetVocab(size_t factorIdx) const {
+    return *vocabs_.at(factorIdx);
+  }
+}

--- a/src/amun/common/factor_vocab.h
+++ b/src/amun/common/factor_vocab.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <string>
+#include <vector>
+#include <memory>
+#include <algorithm>
+
+#include "common/types.h"
+#include "common/vocab.h"
+
+namespace amunmt {
+class FactorVocab {
+  public:
+    FactorVocab(const std::string& path);
+    FactorVocab(const std::vector<std::string>& paths);
+    FactWord operator[](const std::vector<std::string>& factors) const;
+    FactWords operator()(const std::vector<std::vector<std::string>>& lineFactors,
+                                     bool addEOS=true) const;
+    Vocab& GetVocab(size_t factorIdx) const;
+  private:
+    typedef std::unique_ptr<Vocab> VocabPtr;
+    std::vector<VocabPtr> vocabs_;
+};
+}

--- a/src/amun/common/god.h
+++ b/src/amun/common/god.h
@@ -50,7 +50,7 @@ class God {
       return config_.Get(key);
     }
 
-    Vocab& GetSourceVocab(size_t i = 0) const;
+    Vocab& GetSourceVocab(size_t tab = 0, size_t factor = 0) const;
     Vocab& GetTargetVocab() const;
 
     std::istream& GetInputStream() const;
@@ -64,6 +64,8 @@ class God {
     std::vector<std::string> GetScorerNames() const;
     const std::map<std::string, float>& GetScorerWeights() const;
 
+    std::vector<std::vector<std::string>> Preprocess
+      (size_t i, const std::vector<std::vector<std::string>>& input) const;
     std::vector<std::string> Preprocess(size_t i, const std::vector<std::string>& input) const;
     std::vector<std::string> Postprocess(const std::vector<std::string>& input) const;
 
@@ -85,7 +87,11 @@ class God {
 
     Config config_;
 
-    mutable std::vector<std::unique_ptr<Vocab>> sourceVocabs_;
+    typedef std::unique_ptr<Vocab> VocabPtr;
+    // a vocabulary for each of the source side factors
+    typedef std::vector<VocabPtr> FactorVocabs;
+    // a list of source side factor vocabularies for each of the tabs
+    mutable std::vector<FactorVocabs> sourceVocabs_;
     mutable std::unique_ptr<Vocab> targetVocab_;
 
     std::shared_ptr<const Filter> filter_;

--- a/src/amun/common/god.h
+++ b/src/amun/common/god.h
@@ -13,6 +13,7 @@
 #include "common/base_best_hyps.h"
 #include "common/output_collector.h"
 #include "common/vocab.h"
+#include "common/factor_vocab.h"
 #include "common/threadpool.h"
 #include "common/file_stream.h"
 #include "common/filter.h"
@@ -24,6 +25,7 @@ namespace amunmt {
 class Search;
 class Weights;
 class Vocab;
+class FactorVocab;
 class Filter;
 class InputFileStream;
 
@@ -51,6 +53,7 @@ class God {
     }
 
     Vocab& GetSourceVocab(size_t tab = 0, size_t factor = 0) const;
+    FactorVocab& GetSourceVocabs(size_t tab=0) const;
     Vocab& GetTargetVocab() const;
 
     std::istream& GetInputStream() const;
@@ -87,11 +90,8 @@ class God {
 
     Config config_;
 
-    typedef std::unique_ptr<Vocab> VocabPtr;
-    // a vocabulary for each of the source side factors
-    typedef std::vector<VocabPtr> FactorVocabs;
     // a list of source side factor vocabularies for each of the tabs
-    mutable std::vector<FactorVocabs> sourceVocabs_;
+    mutable std::vector<FactorVocab> sourceVocabs_;
     mutable std::unique_ptr<Vocab> targetVocab_;
 
     std::shared_ptr<const Filter> filter_;

--- a/src/amun/common/processor/bpe.cpp
+++ b/src/amun/common/processor/bpe.cpp
@@ -10,6 +10,10 @@
 
 namespace amunmt {
 
+std::vector<bpeFactors> BPE::Preprocess(const std::vector<bpeFactors> input) const {
+  return Encode(input);
+}
+
 std::vector<std::string> BPE::Preprocess(const std::vector<std::string> input) const {
   return Encode(input);
 }
@@ -189,15 +193,30 @@ std::vector<std::string>& BPE::Encode(const std::string& word) const {
   return cache_[word];
 }
 
+std::vector<bpeFactors> BPE::Encode(const std::vector<bpeFactors>& words) const {
+  // split the word into it's BPE parts and append a copy of word's factors to
+  // each of the parts
+  std::vector<std::vector<std::string>> result;
+  for (const bpeFactors& factorlist : words) {
+    std::string word = factorlist[0];
+    std::vector<std::string>& encoded = Encode(word);
+    for (const auto& bpePart : encoded)
+    {
+      result.push_back(bpeFactors());
+      bpeFactors& current = result.back();
+      current.push_back(bpePart);
+      current.insert(current.end(), ++factorlist.begin(), factorlist.end());
+    }
+  }
+  return result;
+}
+
 std::vector<std::string> BPE::Encode(const std::vector<std::string>& words) const {
   std::vector<std::string> result;
   for (const auto& word : words) {
     auto& encoded = Encode(word);
     result.insert(result.end(), encoded.begin(), encoded.end());
   }
-  // std::cerr << "BPE: ";
-  // for (auto& code: result) std::cerr << code << " " ;
-  // std::cerr << std::endl;
   return result;
 }
 

--- a/src/amun/common/processor/bpe.h
+++ b/src/amun/common/processor/bpe.h
@@ -33,6 +33,8 @@ namespace std
 
 namespace amunmt {
 
+typedef std::vector<std::string> bpeFactors;
+
 class BPE : public Processor {
   using BPEPair = std::pair<std::string, std::string>;
 
@@ -48,9 +50,11 @@ class BPE : public Processor {
 
     std::vector<std::string>& Encode(const std::string& word) const;
 
+    std::vector<bpeFactors> Encode(const std::vector<bpeFactors>& words) const;
     std::vector<std::string> Encode(const std::vector<std::string>& words) const;
 
     std::vector<std::string> Preprocess(const std::vector<std::string> input) const;
+    std::vector<bpeFactors> Preprocess(const std::vector<bpeFactors> input) const;
     std::vector<std::string> Postprocess(const std::vector<std::string> input) const;
 
     virtual ~BPE() {}

--- a/src/amun/common/processor/processor.h
+++ b/src/amun/common/processor/processor.h
@@ -9,6 +9,7 @@ namespace amunmt {
 class Preprocessor {
   public:
     virtual std::vector<std::string> Preprocess(const std::vector<std::string> input) const = 0;
+    virtual std::vector<std::vector<std::string>> Preprocess(const std::vector<std::vector<std::string>> input) const = 0;
     virtual ~Preprocessor() {}
 };
 

--- a/src/amun/common/sentence.cpp
+++ b/src/amun/common/sentence.cpp
@@ -33,27 +33,12 @@ Sentence::Sentence(const God &god, size_t vLineNum, const std::string& line)
     }
 
     auto processed = god.Preprocess(i, lineFactors);
-    // TODO: refactor the rest of the code to use the structured
-    // vector of vector of factor representation everywhere.
-    // Currently we merge it into a single (periodic) vector
-    // of factors, i.e., w11 f11 f12 f13 w21 f21 f22 f23 ...
-    // for compatability reasons
-    // std::vector<std::string> merged;
-    words_.push_back(std::vector<Word>());
-    for (const std::vector<std::string>& wordFactors : processed) {
-      size_t vocabIdx = 0;
-      for (const std::string& factor : wordFactors) {
-        words_.back().push_back(god.GetSourceVocab(i, vocabIdx++)[factor]);
-      }
-      // merged.insert(merged.end(), wordFactors.begin(), wordFactors.end());
-      // words_.push_back(god.GetSourceVocab(i++)(merged));
+    factors_.emplace_back(god.GetSourceVocabs(i)(processed));
+    Words lineWords(factors_.back().size());
+    for (size_t i = 0; i < factors_.back().size(); ++i) {
+      lineWords[i] = factors_.back()[i][0];
     }
-    // previously EOS_ID was added when calling vocab's () operator
-    // now we add them manually but should refactor it back when
-    // factor related stuff is properly refactored
-    for (size_t i = 0; i < processed.back().size(); ++i) {
-      words_.back().push_back(EOS_ID);
-    }
+    words_.emplace_back(lineWords);
     i++;
   }
 }
@@ -76,6 +61,10 @@ size_t Sentence::GetLineNum() const {
 
 const Words& Sentence::GetWords(size_t index) const {
   return words_[index];
+}
+
+const FactWords& Sentence::GetFactors(size_t index) const {
+  return factors_[index];
 }
 
 size_t Sentence::size(size_t index) const {

--- a/src/amun/common/sentence.cpp
+++ b/src/amun/common/sentence.cpp
@@ -47,13 +47,26 @@ Sentence::Sentence(const God &god, size_t lineNum, const std::vector<std::string
   : lineNum_(lineNum) {
     auto processed = god.Preprocess(0, words);
     words_.push_back(god.GetSourceVocab(0)(processed));
+    // fill in the factors as well so that there aren't any surprises
+    // if somebody decides to look up the factors in the decoder or something
+    FillDummyFactors(words_.back());
 }
 
 Sentence::Sentence(God&, size_t lineNum, const std::vector<size_t>& words)
   : lineNum_(lineNum) {
     words_.push_back(words);
+    // fill in the factors as well so that there aren't any surprises
+    // if somebody decides to look up the factors in the decoder or something
+    FillDummyFactors(words_.back());
 }
 
+void Sentence::FillDummyFactors(const Words& line) {
+  factors_.emplace_back(FactWords(line.size(), FactWord(1)));
+  FactWords& factline = factors_.back();
+  for (size_t i = 0; i < line.size(); ++i) {
+    factline[i][0] = line[i];
+  }
+}
 
 size_t Sentence::GetLineNum() const {
   return lineNum_;

--- a/src/amun/common/sentence.cpp
+++ b/src/amun/common/sentence.cpp
@@ -25,8 +25,36 @@ Sentence::Sentence(const God &god, size_t vLineNum, const std::string& line)
       lineTokens.resize(maxLength);
     }
 
-    auto processed = god.Preprocess(i, lineTokens);
-    words_.push_back(god.GetSourceVocab(i++)(processed));
+    std::vector<std::vector<std::string>> lineFactors;
+    for (const std::string& token : lineTokens) {
+      std::vector<std::string> wordFactors;
+      Split(token, wordFactors, "|");
+      lineFactors.push_back(wordFactors);
+    }
+
+    auto processed = god.Preprocess(i, lineFactors);
+    // TODO: refactor the rest of the code to use the structured
+    // vector of vector of factor representation everywhere.
+    // Currently we merge it into a single (periodic) vector
+    // of factors, i.e., w11 f11 f12 f13 w21 f21 f22 f23 ...
+    // for compatability reasons
+    // std::vector<std::string> merged;
+    words_.push_back(std::vector<Word>());
+    for (const std::vector<std::string>& wordFactors : processed) {
+      size_t vocabIdx = 0;
+      for (const std::string& factor : wordFactors) {
+        words_.back().push_back(god.GetSourceVocab(i, vocabIdx++)[factor]);
+      }
+      // merged.insert(merged.end(), wordFactors.begin(), wordFactors.end());
+      // words_.push_back(god.GetSourceVocab(i++)(merged));
+    }
+    // previously EOS_ID was added when calling vocab's () operator
+    // now we add them manually but should refactor it back when
+    // factor related stuff is properly refactored
+    for (size_t i = 0; i < processed.back().size(); ++i) {
+      words_.back().push_back(EOS_ID);
+    }
+    i++;
   }
 }
 

--- a/src/amun/common/sentence.h
+++ b/src/amun/common/sentence.h
@@ -16,6 +16,7 @@ class Sentence {
 		Sentence(God &god, size_t lineNum, const std::vector<size_t>& words);
 
     const Words& GetWords(size_t index = 0) const;
+    const FactWords& GetFactors(size_t index = 0) const;
     size_t size(size_t index = 0) const;
 
     size_t GetLineNum() const;
@@ -23,6 +24,7 @@ class Sentence {
 
   private:
     std::vector<Words> words_;
+    std::vector<FactWords> factors_;
     size_t lineNum_;
 
     Sentence(const Sentence &) = delete;

--- a/src/amun/common/sentence.h
+++ b/src/amun/common/sentence.h
@@ -33,4 +33,3 @@ using SentencePtr = std::shared_ptr<Sentence>;
 
 
 }
-

--- a/src/amun/common/sentence.h
+++ b/src/amun/common/sentence.h
@@ -23,6 +23,8 @@ class Sentence {
 
 
   private:
+    void FillDummyFactors(const Words& line);
+
     std::vector<Words> words_;
     std::vector<FactWords> factors_;
     size_t lineNum_;

--- a/src/amun/common/types.h
+++ b/src/amun/common/types.h
@@ -7,6 +7,10 @@
 
 namespace amunmt {
 
+typedef size_t Factor;
+typedef std::vector<Factor> FactWord;
+typedef std::vector<FactWord> FactWords;
+
 typedef size_t Word;
 typedef std::vector<Word> Words;
 

--- a/src/amun/gpu/decoder/ape_penalty.cu
+++ b/src/amun/gpu/decoder/ape_penalty.cu
@@ -65,7 +65,9 @@ ApePenaltyLoader::ApePenaltyLoader(const std::string& name,
 
 void ApePenaltyLoader::Load() {
   size_t tab = Has("tab") ? Get<size_t>("tab") : 0;
-  const Vocab& svcb = God::GetSourceVocab(tab);
+  // TODO: is the word surface form vocabulary (0th factor) what is needed here?
+  const size_t factor = 0;
+  const Vocab& svcb = God::GetSourceVocab(tab, factor);
   const Vocab& tvcb = God::GetTargetVocab();
 
   srcTrgMap_.resize(svcb.size(), UNK);

--- a/src/amun/gpu/dl4mt/encoder.cu
+++ b/src/amun/gpu/dl4mt/encoder.cu
@@ -66,45 +66,65 @@ void Encoder::Encode(const Sentences& source, size_t tab, mblas::Matrix& context
                          mblas::IMatrix &sentencesMask)
 {
   size_t maxSentenceLength = GetMaxLength(source, tab);
+  size_t maxMergedLength = maxSentenceLength / embeddings_.FactorCount();
 
   //cerr << "1dMapping=" << mblas::Debug(dMapping, 2) << endl;
-  HostVector<uint> hMapping(maxSentenceLength * source.size(), 0);
+  HostVector<uint> hMapping(maxMergedLength * source.size(), 0);
   for (size_t i = 0; i < source.size(); ++i) {
-    for (size_t j = 0; j < source.at(i)->GetWords(tab).size(); ++j) {
-      hMapping[i * maxSentenceLength + j] = 1;
+    for (size_t j = 0; j < source.at(i)->GetWords(tab).size() / embeddings_.FactorCount(); ++j) {
+      hMapping[i * maxMergedLength + j] = 1;
     }
   }
 
-  sentencesMask.NewSize(maxSentenceLength, source.size(), 1, 1);
+  sentencesMask.NewSize(maxMergedLength, source.size(), 1, 1);
   mblas::copy(thrust::raw_pointer_cast(hMapping.data()),
               hMapping.size(),
               sentencesMask.data(),
               cudaMemcpyHostToDevice);
 
   //cerr << "GetContext1=" << context.Debug(1) << endl;
-  context.NewSize(maxSentenceLength,
+  context.NewSize(maxMergedLength,
                  forwardRnn_.GetStateLength().output + backwardRnn_.GetStateLength().output,
                  1,
                  source.size());
   //cerr << "GetContext2=" << context.Debug(1) << endl;
 
   auto input = GetBatchInput(source, tab, maxSentenceLength);
+  // input is a sentence; sentence is a vector of batches; batch is a vector of words
+  // we'll convert each word into a vector of factors by combining every number-of-factors
+  // batches together
+  std::vector<std::vector<std::vector<size_t>>> mergedInput(input.size() / embeddings_.FactorCount());
+  for (size_t i = 0; i < input.size(); ) {
+    std::vector<std::vector<size_t>> newbatch
+      // asume that batchsize is the same for each of the factors of a single word
+      (input[i].size(), std::vector<size_t>(embeddings_.FactorCount()));
 
-  for (size_t i = 0; i < input.size(); ++i) {
+    for (size_t factorIdx = 0; factorIdx < embeddings_.FactorCount(); ++factorIdx) {
+      const std::vector<size_t>& batch = input[i];
+
+      for (size_t j = 0; j < batch.size(); ++j) {
+        newbatch.at(j)[factorIdx] = batch[j];
+      }
+      ++i;
+    }
+    mergedInput[i / embeddings_.FactorCount() - 1] = newbatch;
+  }
+
+  for (size_t i = 0; i < mergedInput.size(); ++i) {
     if (i >= embeddedWords_.size()) {
       embeddedWords_.emplace_back();
     }
-    embeddings_.Lookup(embeddedWords_[i], input[i]);
+    embeddings_.Lookup(embeddedWords_[i], mergedInput[i]);
     //cerr << "embeddedWords_=" << embeddedWords_.back().Debug(true) << endl;
   }
 
   //cerr << "GetContext3=" << context.Debug(1) << endl;
   forwardRnn_.Encode(embeddedWords_.cbegin(),
-                         embeddedWords_.cbegin() + maxSentenceLength,
+                         embeddedWords_.cbegin() + maxMergedLength,
                          context, source.size(), false);
   //cerr << "GetContext4=" << context.Debug(1) << endl;
 
-  backwardRnn_.Encode(embeddedWords_.crend() - maxSentenceLength,
+  backwardRnn_.Encode(embeddedWords_.crend() - maxMergedLength,
                           embeddedWords_.crend() ,
                           context, source.size(), true, &sentencesMask);
   //cerr << "GetContext5=" << context.Debug(1) << endl;

--- a/src/amun/gpu/dl4mt/encoder.h
+++ b/src/amun/gpu/dl4mt/encoder.h
@@ -28,19 +28,56 @@ class Encoder {
         : w_(model)
         {}
 
-        void Lookup(mblas::Matrix& Row, const Words& words) {
-          HostVector<uint> knownWords(words.size(), 1);
+        void Lookup(mblas::Matrix& Row, const std::vector<std::vector<Word>>& words) {
+          std::vector<HostVector<uint>> knownWords(w_.Es_.size(),
+                                                   HostVector<uint>(words.size(), 1));
+          size_t factorCount = w_.Es_.size();
           for (size_t i = 0; i < words.size(); ++i) {
-            if (words[i] < w_.E_->dim(0)) {
-              knownWords[i] = words[i];
+            const std::vector<Word>& factors = words[i];
+            for (size_t factorIdx = 0; factorIdx < factors.size(); ++factorIdx) {
+              const Word& factor = factors[factorIdx];
+              const std::shared_ptr<mblas::Matrix>& Emb = w_.Es_.at(factorIdx);
+
+              if (factor < Emb->dim(0)) {
+                knownWords[factorIdx][i] = factor;
+              }
             }
           }
+          /* HANDLE_ERROR( cudaStreamSynchronize(mblas::CudaStreamHandler::GetStream())); */
+          /* std::cerr << "Embeddings::Lookup1" << std::endl; */
 
-          DeviceVector<uint> dKnownWords(knownWords);
+          size_t wordCount = words.size() / factorCount;
+          //Row.NewSize(0, wordCount);
+          /* std::vector<std::shared_ptr<mblas::Matrix>>::iterator eit = w_.Es_.begin(); */
+          /* std::vector<HostVector<uint>>::iterator wit = knownWords.begin(); */
+          for (size_t i = 0; i < knownWords.size(); i++) {
+            const HostVector<uint>& factorWords = knownWords.at(i);
+            DeviceVector<uint> dKnownWords(factorWords);
 
-          Row.NewSize(words.size(), w_.E_->dim(1));
-          mblas::Assemble(Row, *w_.E_, dKnownWords);
+            const std::shared_ptr<mblas::Matrix>& Emb = w_.Es_.at(i);
+            mblas::Matrix factorRow;
+            factorRow.NewSize(wordCount, Emb->dim(1));
+            mblas::Assemble(factorRow, *Emb, dKnownWords);
+            mblas::Transpose(factorRow);
+
+            if (i > 0) {
+              mblas::Concat(Row, factorRow);
+            } else {
+              mblas::Copy(Row, factorRow);
+            }
+
+            /* eit++; */
+            /* wit++; */
+          }
+          mblas::Transpose(Row);
+
+          /* Row.NewSize(words.size(), w_.E_->dim(1)); */
+          /* mblas::Assemble(Row, *w_.E_, dKnownWords); */
           //std::cerr << "Row3=" << Row.Debug(1) << std::endl;
+        }
+
+        size_t FactorCount() {
+          return w_.Es_.size();
         }
 
       private:

--- a/src/amun/gpu/dl4mt/model.h
+++ b/src/amun/gpu/dl4mt/model.h
@@ -18,10 +18,22 @@ struct Weights {
     EncEmbeddings(const EncEmbeddings&) = delete;
 
     EncEmbeddings(const NpzConverter& model)
-    : E_(model.get("Wemb", true))
-    {}
+    {
+      Es_.emplace_back(model.get("Wemb", true));
 
-    const std::shared_ptr<mblas::Matrix> E_;
+      for(int i=1; true; i++) {
+        std::string factorKey = "Wemb" + std::to_string(i);
+        std::shared_ptr<mblas::Matrix> factorEmb = model.get(factorKey, false);
+        if (factorEmb->size() <= 0){
+          break;
+        }
+        Es_.emplace_back(factorEmb);
+      }
+    }
+
+    // Embedding matrices for word factors. The first factor is the word
+    // surface form. The rest are optional.
+    std::vector<std::shared_ptr<mblas::Matrix>> Es_;
   };
 
   struct EncForwardGRU {


### PR DESCRIPTION
Implements Nematus-style factors in the encoder as discussed in #14 

This is a preliminary version as suggested by @tomekd - `sentence.h` outputs a flat list of factors
```
w1 f11 f12 f13 w2 f21 f22 f23 w3 f31 f32...
```
which is then picked up by the `Encoder` and fed into `Embeddings::Lookup`.

The code is working, but should probably not be merged yet, before everything's refactored to pass around a structured vector of factors (instead of a flat one). Without that there's a bit of a mess going on in `Encoder::Encode`. Also there's no documentation yet. If anyone want's to run this, the factor vocabularies can be specified like so:
```yml
# ...
source-vocab:
  - - vocabs/source-word-vocab.json
    - vocabs/source-factor1.json
    - vocabs/source-factor2.json
    - vocabs/source-factor3.json
    - vocabs/source-factor4.json
target-vocab: vocabs/target.json
```
Also model loading now seems to take a bit longer than it should and I haven't gotten around to finding out why.

Anyway, I'm leaving this here in case there's anything I should change before moving forward. E.g., what is the correct way to handle the situation when the word has more/less factors than there are vocabularies and embedding matrices?