### PR TITLE
avoid updating marian submodule to its head

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,7 +45,7 @@ if(CUDA)
     message("-- Compiling with CUDA support")
     
     if (MARIAN)
-      execute_process(COMMAND git submodule update --init --recursive --remote --no-fetch
+      execute_process(COMMAND git submodule update --init --recursive --no-fetch
                       WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
     endif(MARIAN)
 


### PR DESCRIPTION
Fixes the following issue:

When I checkout a particular commit of this repo, the outer one, I would expect to get submodules at their corresponding commits.
The following sequence of commands however fails, because cmake always updates submodules to their newest state:

```
git clone https://github.com/marian-nmt/marian.git
cd marian
git checkout 752deedb08980d58cd23c12d3b91e279ff4159f0
  # get the old commit we want
git submodule update --recursive
  # get old state also for submodules
mkdir build
cd build
cmake ..
  # due to --remote, cmake updated submodules
make
```