### PR TITLE
Print n-best list alignments and soft alignments for each n-best candidate

### DIFF
--- a/src/amun/common/printer.h
+++ b/src/amun/common/printer.h
@@ -55,7 +55,10 @@ void Printer(const God &god, const History& history, OStream& out, const Sentenc
       }
       std::string translation = Join(god.Postprocess(god.GetTargetVocab()(words)));
       if (god.Get<bool>("return-alignment")) {
-        translation += GetAlignmentString(GetAlignment(bestTranslation.second));
+        translation += GetAlignmentString(GetAlignment(hypo));
+      }
+      if (god.Get<bool>("return-soft-alignment")) {
+        translation += GetSoftAlignmentString(hypo);
       }
       out << history.GetLineNum() << " ||| " << translation << " |||";
 


### PR DESCRIPTION
The alignments printed were, for each candidate line, the alignments of the best hypothesis, and the soft alignments were missing. These small changes fix that and print each n-best candidate line in a similar way to the best hypothesis returned.

Closes #159 