### PR TITLE
Adding support for pyhton libloading in macOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,6 +83,9 @@ elseif (APPLE)
       set(BOOST_PYTHON_VERSION_NAME "python")
     endif(NOT PYTHON_VERSION_NORMALIZED EQUAL 27)
 
+    # On macOS, python isn't able to load dylib libraries. Renaming them to .so solves this problem
+    set(CMAKE_SHARED_LIBRARY_SUFFIX ".so")
+
     find_package(Boost COMPONENTS system filesystem program_options timer iostreams ${BOOST_PYTHON_VERSION_NAME} thread chrono)
 endif (UNIX AND NOT APPLE)
 


### PR DESCRIPTION
Currently CMake generates makefiles that links libraries with the extension `.dylib`. On macOS Python isn't able to load these files ([reference](https://stackoverflow.com/a/2582504)).

This patch changes this by creating `llibamunmt` with the extension `.so` instead of `.dylib`, making it possible to use with python on macOS

